### PR TITLE
[feature/aketer-12] 브랜트 톤 적용 노드 구현 및 기존 랭그래프 구조 리팩터링

### DIFF
--- a/src/main/java/com/amore/aketer/domain/enums/RecommendTargetType.java
+++ b/src/main/java/com/amore/aketer/domain/enums/RecommendTargetType.java
@@ -1,0 +1,7 @@
+package com.amore.aketer.domain.enums;
+
+public enum RecommendTargetType {
+    USER,
+    PERSONA
+}
+

--- a/src/main/java/com/amore/aketer/domain/recommend/Recommend.java
+++ b/src/main/java/com/amore/aketer/domain/recommend/Recommend.java
@@ -1,0 +1,50 @@
+package com.amore.aketer.domain.recommend;
+
+import com.amore.aketer.domain.common.BaseEntity;
+import com.amore.aketer.domain.enums.ChannelType;
+import com.amore.aketer.domain.enums.RecommendTargetType;
+import com.amore.aketer.domain.item.Item;
+import com.amore.aketer.domain.message.Message;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "recommend")
+public class Recommend extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private RecommendTargetType targetType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel_type", length = 20)
+    private ChannelType channelType;
+
+    @Column(name = "scheduled_at")
+    private LocalDateTime scheduledAt;
+
+    @Lob
+    @Column(name = "recommend_reason")
+    private String recommendReason;
+}

--- a/src/main/java/com/amore/aketer/workflow/online/agent/graph/MessageGraph.java
+++ b/src/main/java/com/amore/aketer/workflow/online/agent/graph/MessageGraph.java
@@ -28,7 +28,8 @@ public class MessageGraph {
     private final ValidateDeliveryStrategyNode validateDeliveryStrategyNode;
     private final DraftMarketingMessageNode draftMarketingMessageNode;
     private final ApplyBrandToneNode applyBrandToneNode;
-    private final ValidateMessageAndToneNode validateMessageAndToneNode;
+    private final ValidateDraftMessageNode validateDraftMessageNode;
+    private final ValidateBrandToneNode validateBrandToneNode;
     private final ValidateEthicsPolicyNode validateEthicsPolicyNode;
     private final RegenerationNode regenerationNode;
     private final GenerateEthicsPolicyKeywordNode generateEthicsPolicyKeywordNode;
@@ -49,11 +50,14 @@ public class MessageGraph {
                 // 마케팅 메시지 생성 노드
                 .addNode("draft_marketing_message", draftMarketingMessageNode)
 
+                // 초안 검증 노드
+                .addNode("validate_draft_message", validateDraftMessageNode)
+
                 // 브랜드 톤 적용 노드
                 .addNode("apply_brand_tone", applyBrandToneNode)
 
-                // 메시지, 브랜드 톤 적합성 검증 노드
-                .addNode("validate_message_and_tone", validateMessageAndToneNode)
+                // 브랜드 톤 검증 노드
+                .addNode("validate_brand_tone", validateBrandToneNode)
 
                 // 윤리 강령 검색 키워드 추천 노드
                 .addNode("generate_ethics_policy_keyword", generateEthicsPolicyKeywordNode)
@@ -83,17 +87,24 @@ public class MessageGraph {
                         Map.of("fail", "determine_delivery_strategy",
                                 "pass", "draft_marketing_message"))
 
-                // 마케팅 메시지 생성 노드 -> 브랜드 톤 적용 노드
-                .addEdge("draft_marketing_message", "apply_brand_tone")
+                // 마케팅 메시지 초안 생성 노드 -> 마케팅 초안 메시지 검증 노드
+                .addEdge("draft_marketing_message", "validate_draft_message")
 
-                // 브랜드 톤 적용 노드 -> 메시지, 브랜드 톤 적합성 검증 노드
-                .addEdge("apply_brand_tone", "validate_message_and_tone")
-
-                // 메시지, 브랜드 톤 적합성 검증 노드 (검증 결과: 실패) -> 마케팅 메시지 생성 노드
-                //                            (검증 결과: 성공) -> 윤리 강령 검색 키워드 추천 노드
-                .addConditionalEdges("validate_message_and_tone",
-                        messageRoute(),
+                // 메시지 초안 적합성 검증 노드 (검증 결과: 실패) -> 마케팅 메시지 생성 노드
+                //                        (검증 결과: 성공) -> 브랜드 톤 적용 노드
+                .addConditionalEdges("validate_draft_message",
+                        draftMessageRoute(),
                         Map.of("fail", "draft_marketing_message",
+                                "pass", "apply_brand_tone"))
+
+                // 브랜드 톤 적용 노드 -> 브랜드 톤 적합성 검증 노드
+                .addEdge("apply_brand_tone", "validate_brand_tone")
+
+                // 브랜드 톤 적합성 검증 노드  (검증 결과: 실패) -> 브랜드 톤 적용 노드
+                //                       (검증 결과: 성공) -> 윤리 강령 검색 키워드 추천 노드
+                .addConditionalEdges("validate_brand_tone",
+                        brandToneMessageRoute(),
+                        Map.of("fail", "apply_brand_tone",
                                 "pass", "generate_ethics_policy_keyword"))
 
                 // 윤리 강령 검색 키워드 추천 노드 -> 윤리 강령 검색 노드
@@ -123,8 +134,17 @@ public class MessageGraph {
         };
     }
 
-    // 메시지, 브랜드 톤 적합성 검증 노드 분기 조건
-    private AsyncEdgeAction<MessageState> messageRoute() {
+    // 메시지 초안 적합성 검증 노드 분기 조건
+    private AsyncEdgeAction<MessageState> draftMessageRoute() {
+        return state -> {
+            String result = state.getValidation();
+
+            return CompletableFuture.completedFuture(result);
+        };
+    }
+
+    // 브랜드톤 적합성 검증 노드 분기 조건
+    private AsyncEdgeAction<MessageState> brandToneMessageRoute() {
         return state -> {
             String result = state.getValidation();
 

--- a/src/main/java/com/amore/aketer/workflow/online/agent/node/ApplyBrandToneNode.java
+++ b/src/main/java/com/amore/aketer/workflow/online/agent/node/ApplyBrandToneNode.java
@@ -1,17 +1,151 @@
 package com.amore.aketer.workflow.online.agent.node;
 
 import com.amore.aketer.workflow.online.agent.state.MessageState;
+import lombok.RequiredArgsConstructor;
 import org.bsc.langgraph4j.action.AsyncNodeAction;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Component
+@RequiredArgsConstructor
 public class ApplyBrandToneNode implements AsyncNodeAction<MessageState> {
+
+    private final ChatClient chatClient;
+
+    /**
+     * LLM 응답을 구조화하기 위한 레코드
+     * - title: 40자 이내
+     * - body:  350자 이내
+     */
+    public record ToneAppliedMessageResponse(
+            String title,
+            String body,
+            String toneSummary
+    ) {}
 
     @Override
     public CompletableFuture<Map<String, Object>> apply(MessageState state) {
-        return null;
+
+        // ===== 입력 읽기 =====
+        String brand = nvl(state.getBrand());
+        String purpose = nvl(state.getPurpose());
+        String channel = nvl(state.getChannel());
+        String product = nvl(state.getProduct());
+        String productInfo = nvl(state.getProductInformation());
+        String brandGuidelines = nvl(state.getBrandGuidelines());
+
+        String draftTitle = nvl(state.getMessageTitle());
+        String draftBody = nvl(state.getMessageBody());
+
+        // (권장) 브랜드 톤 검증 실패 피드백: 최근 것만 몇 개 사용
+        List<String> toneFailureReasons = safeLast(state.getBrandToneFailureReasons(), 5);
+
+        // ===== LLM 응답 구조화 =====
+        BeanOutputConverter<ToneAppliedMessageResponse> converter =
+                new BeanOutputConverter<>(ToneAppliedMessageResponse.class);
+
+        // ===== 피드백 프롬프트 =====
+        String feedbackSection = "";
+        if (!toneFailureReasons.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("\n[이전 브랜드 톤 검증 실패 사유 (반드시 반영)]\n");
+            for (String r : toneFailureReasons) sb.append("- ").append(r).append("\n");
+            sb.append("위 사유를 해결하도록 문장/어조/표현을 수정해.\n");
+            feedbackSection = sb.toString();
+        }
+
+        // ===== 브랜드 가이드라인 fallback =====
+        // (RAG가 비어있을 수 있으니 최소 안전장치)
+        String guidelineSection = brandGuidelines.isBlank()
+                ? """
+                   [브랜드 톤 가이드라인]
+                   - (가이드라인이 제공되지 않았음) 과장/단정 표현을 피하고, 고객 친화적인 톤으로 자연스럽게 작성해.
+                   - 지나친 느낌표/이모지 남발 금지. 문장 길이는 간결하게.
+                   """
+                : """
+                   [브랜드 톤 가이드라인]
+                   %s
+                   """.formatted(brandGuidelines);
+
+        // ===== 프롬프트 =====
+        String prompt = """
+                너는 아모레퍼시픽의 브랜드 카피라이터야.
+                아래의 '초안 메시지'를 주어진 '브랜드 톤 가이드라인'에 맞게 다듬어 최종 문구를 만들어.
+                
+                [목표]
+                - 초안의 핵심 정보(상품/혜택/CTA)는 유지하되, 문체/어조/표현을 브랜드 톤에 맞게 정교화
+                - 불필요한 과장, 단정, 허위/오해 소지가 있는 표현은 제거
+                - 고객에게 친근하지만 신뢰감 있게
+                - 채널 특성 반영(SMS면 더 간결하게, KAKAO면 가독성/줄바꿈 고려)
+                
+                [출력 형식]
+                - 반드시 아래 JSON 스키마로만 출력해.
+                - title은 40자 이내(공백 포함), body는 350자 이내(공백 포함).
+                - 한국어로 작성.
+                
+                %s
+                %s
+                
+                [메타 정보]
+                - brand: %s
+                - purpose: %s
+                - channel: %s
+                
+                [상품 정보(참고)]
+                - product: %s
+                - productInformation: %s
+                
+                [초안 메시지]
+                - draftTitle: %s
+                - draftBody: %s
+                
+                {format}
+                """.formatted(
+                guidelineSection,
+                feedbackSection,
+                brand, purpose, channel,
+                product, productInfo,
+                draftTitle, draftBody
+        );
+
+        ToneAppliedMessageResponse response = chatClient.prompt()
+                .user(u -> u.text(prompt).param("format", converter.getFormat()))
+                .call()
+                .entity(converter);
+
+        // ===== 후처리(안전장치) =====
+        // - 모델이 간혹 길이를 넘길 수 있으니 최소한으로 클램핑
+        String finalTitle = clamp(nvl(response.title()).trim(), 40);
+        String finalBody = clamp(nvl(response.body()).trim(), 350);
+
+        return CompletableFuture.completedFuture(Map.of(
+                MessageState.MESSAGE_TITLE, finalTitle,
+                MessageState.MESSAGE_BODY, finalBody
+        ));
+    }
+
+    private static String nvl(String s) {
+        return s == null ? "" : s;
+    }
+
+    private static String clamp(String s, int maxLen) {
+        if (s == null) return "";
+        if (s.length() <= maxLen) return s;
+        // 끝에 말줄임표를 붙일 공간 확보
+        if (maxLen <= 1) return s.substring(0, maxLen);
+        return s.substring(0, maxLen - 1) + "…";
+    }
+
+    private static List<String> safeLast(List<String> list, int n) {
+        if (list == null || list.isEmpty()) return List.of();
+        int size = list.size();
+        int from = Math.max(0, size - n);
+        return new ArrayList<>(list.subList(from, size));
     }
 }

--- a/src/main/java/com/amore/aketer/workflow/online/agent/node/DraftMarketingMessageNode.java
+++ b/src/main/java/com/amore/aketer/workflow/online/agent/node/DraftMarketingMessageNode.java
@@ -52,7 +52,7 @@ public class DraftMarketingMessageNode implements AsyncNodeAction<MessageState> 
         String productInfo = state.getProductInformation();
         String channel = state.getChannel();
         String sendTime = state.getSendTime() != null ? state.getSendTime().toString() : "미정";
-        List<String> failureReasons = state.getMessageFailureReasons();
+        List<String> failureReasons = state.getDraftMessageFailureReasons();
 
         //==LLM 응답 구조화==/
         BeanOutputConverter<DraftMessageResponse> converter = new BeanOutputConverter<>(DraftMessageResponse.class);

--- a/src/main/java/com/amore/aketer/workflow/online/agent/node/ValidateBrandToneNode.java
+++ b/src/main/java/com/amore/aketer/workflow/online/agent/node/ValidateBrandToneNode.java
@@ -1,0 +1,17 @@
+package com.amore.aketer.workflow.online.agent.node;
+
+import com.amore.aketer.workflow.online.agent.state.MessageState;
+import org.bsc.langgraph4j.action.AsyncNodeAction;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class ValidateBrandToneNode implements AsyncNodeAction<MessageState> {
+
+    @Override
+    public CompletableFuture<Map<String, Object>> apply(MessageState state) {
+        return null;
+    }
+}

--- a/src/main/java/com/amore/aketer/workflow/online/agent/node/ValidateDraftMessageNode.java
+++ b/src/main/java/com/amore/aketer/workflow/online/agent/node/ValidateDraftMessageNode.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Component
-public class ValidateMessageAndToneNode implements AsyncNodeAction<MessageState> {
+public class ValidateDraftMessageNode implements AsyncNodeAction<MessageState> {
 
     @Override
     public CompletableFuture<Map<String, Object>> apply(MessageState state) {

--- a/src/main/java/com/amore/aketer/workflow/online/agent/state/MessageState.java
+++ b/src/main/java/com/amore/aketer/workflow/online/agent/state/MessageState.java
@@ -37,28 +37,30 @@ public class MessageState extends AgentState {
 
 	// Validation failure reasons
 	public static final String DELIVERY_STRATEGY_FAILURE_REASONS = "deliveryStrategyFailureReasons";
-	public static final String MESSAGE_FAILURE_REASONS = "messageFailureReasons";
-	public static final String ETHICS_FAILURE_REASONS = "ethicsFailureReasons";
+    public static final String DRAFT_MESSAGE_FAILURE_REASONS = "draftMessageFailureReasons";
+    public static final String BRAND_TONE_FAILURE_REASONS = "brandToneFailureReasons";
+    public static final String ETHICS_FAILURE_REASONS = "ethicsFailureReasons";
 
 	// Schema Definition
-	public static final Map<String, Channel<?>> SCHEMA = Map.ofEntries(
-		Map.entry(PERSONA, Channels.base(() -> "")),
-		Map.entry(PRODUCT, Channels.base(() -> "")),
-		Map.entry(BRAND, Channels.base(() -> "")),
-		Map.entry(PURPOSE, Channels.base(() -> "")),
-		Map.entry(CHANNEL, Channels.base(() -> "")),
-		Map.entry(SEND_TIME, Channels.base(() -> LocalDateTime.MIN)),
+    public static final Map<String, Channel<?>> SCHEMA = Map.ofEntries(
+        Map.entry(PERSONA, Channels.base(() -> "")),
+        Map.entry(PRODUCT, Channels.base(() -> "")),
+        Map.entry(BRAND, Channels.base(() -> "")),
+        Map.entry(PURPOSE, Channels.base(() -> "")),
+        Map.entry(CHANNEL, Channels.base(() -> "")),
+        Map.entry(SEND_TIME, Channels.base(() -> LocalDateTime.MIN)),
         Map.entry(STRATEGY_REASON, Channels.base(() -> "")),
-		Map.entry(MESSAGE_TITLE, Channels.base(() -> "")),
-		Map.entry(MESSAGE_BODY, Channels.base(() -> "")),
-		Map.entry(PRODUCT_INFORMATION, Channels.base(() -> "")),
-		Map.entry(BRAND_GUIDELINES, Channels.base(() -> "")),
-		Map.entry(ETHICS_POLICY_GUIDELINES, Channels.base(() -> "")),
+        Map.entry(MESSAGE_TITLE, Channels.base(() -> "")),
+        Map.entry(MESSAGE_BODY, Channels.base(() -> "")),
+        Map.entry(PRODUCT_INFORMATION, Channels.base(() -> "")),
+        Map.entry(BRAND_GUIDELINES, Channels.base(() -> "")),
+        Map.entry(ETHICS_POLICY_GUIDELINES, Channels.base(() -> "")),
         Map.entry(VALIDATION, Channels.base(() -> "")),
-		Map.entry(DELIVERY_STRATEGY_FAILURE_REASONS, Channels.appender(ArrayList::new)),
-		Map.entry(MESSAGE_FAILURE_REASONS, Channels.appender(ArrayList::new)),
-		Map.entry(ETHICS_FAILURE_REASONS, Channels.appender(ArrayList::new))
-	);
+        Map.entry(DELIVERY_STRATEGY_FAILURE_REASONS, Channels.appender(ArrayList::new)),
+        Map.entry(DRAFT_MESSAGE_FAILURE_REASONS, Channels.appender(ArrayList::new)),
+        Map.entry(BRAND_TONE_FAILURE_REASONS, Channels.appender(ArrayList::new)),
+        Map.entry(ETHICS_FAILURE_REASONS, Channels.appender(ArrayList::new))
+    );
 
 	public MessageState(Map<String, Object> initData) {
 		super(initData);
@@ -130,8 +132,12 @@ public class MessageState extends AgentState {
         return this.<List<String>>value(DELIVERY_STRATEGY_FAILURE_REASONS).orElse(new ArrayList<>());
     }
 
-    public List<String> getMessageFailureReasons() {
-        return this.<List<String>>value(MESSAGE_FAILURE_REASONS).orElse(new ArrayList<>());
+    public List<String> getDraftMessageFailureReasons() {
+        return this.<List<String>>value(DRAFT_MESSAGE_FAILURE_REASONS).orElse(new ArrayList<>());
+    }
+
+    public List<String> getBrandToneFailureReasons() {
+        return this.<List<String>>value(BRAND_TONE_FAILURE_REASONS).orElse(new ArrayList<>());
     }
 
     public List<String> getEthicsFailureReasons() {


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 브랜드 톤 적용 노드 구현
    - 기존 랭그래프 구조 리팩터링
    - 추천 엔티티 구현

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 재정님이 AgentState 쪽 수정하시면 이 노드도 수정사항이 생길 것 같습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : YES

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No